### PR TITLE
22 prp zenroom calling convention

### DIFF
--- a/10/README.md
+++ b/10/README.md
@@ -6,23 +6,23 @@ status: Raw
 editor: Jürgen Eckel <juergen@riddleandcode.com>, Thomas Fürstner <tom@riddleandcode.com>, Lorenz Herzberger <lorenzherzberger@gmail.com>
 ```
 
-## Abstract
+# Abstract
 Planetmint integrates Zenroom smart contracts via the integration of zenroom into [cryptoconditions](https://github.com/planetmint/cryptoconditions).
 At this point in time, bitcoin-like smart contracts are supported. These contracts lack the possibilities of internal states. That implies that the conditions and the statements that fulfill them need to be transacted within the very same transaction.
 The propsoal of this PRP is to extend the contracts to support states. This is expected to be done in such a way that the states can be changed with new transactions.
 
 
-## Motivation
+# Motivation
 Smart contract need to support state in order to enable asynchronous and party-independent processing of contracts.
 
-## Specification
+# Specification
 A new optional `script` tag is added to the transaction specification:
 
 It is defined as follows:
 ```json
 {
-  "script": {
-    "code": {
+  "script": 
+  {    "code": {
       "type": "string",
       "raw": "string",
       "parameters": "object", // or
@@ -36,27 +36,109 @@ It is defined as follows:
 }
 ```
 
-The contract is supposed to write the result into ['script']['output'] and the caller has to verfiy if the outcome is as expected. The caller does so with the help of the fulfillment-script.
+The contract is supposed to write the result into ['script']['output'] and the caller has to verfiy if the outcome is as expected. The caller can verify the result with the fulfillment-script.
 
 For a more detailed explaination please refer to the transaction specification in [PRP-9](../9)
 
-## Input
-The ['script']['input'] is an arbitrary JSON data blobs. 
+# Input
+The ['script']['input'] is an arbitrary JSON data blob. 
 
-### Preperation
+## Preperation
 The planetmint node prepares the inputs in such a way that the incoming data is mapped to the following data blobs as follows:
 
-#### Data mappings
+## Data mappings
 * ['data']['input']        <- ['script']['input']
 
-### Result - contract output
+## Result - contract output
 The contract output and result is written to ['script']['output'] and depends completley on the the contract itself. The caller therefore has to verify the result and the outcome. For a stateful smart contract the output hold the state of the contract after the state transition.  
 
-### States of Smart Contracts
+## States of Smart Contracts
 The state of the smart contract will be written to ['script']['output']. The state can then be referenced with the ['script']['state'] which either represents the initial state of the contract or the latest transaction that holds the current state.
 
-### Contract Creation
-The creation of a contract is very simple. A `CREATE` transaction must be called defining all the parameters for the contract. A creator of a contract must provide the ['code']['type'] (e.g.: Zenroom, Solidity, etc.), the actual ['code']]['raw'] and the input ['code']['parameters'] for the contract.
+## Contract/Script Creation
+The following paragraphs will walk you through the creation of a zenroom contract/script on planetmint. The code that this is derived from can be found in the [acceptance tests](https://github.com/planetmint/planetmint/blob/main/acceptance/python/src/test_zenroom.py) of planetmint.
 
-#### Reusealbe contracts - state-ful contracts
+The creation of a contract/script is very simple. 
+
+The script is encoded into a cryptocondition and contains the conditions that need to be fulfilled (e.g. FULFILL_SCRIPT).
+
+```python
+zenroomscpt = ZenroomSha256(
+                script=FULFILL_SCRIPT,
+                data=INITIAL_STATE,
+                keys=zen_public_keys)
+```
+The condition will be encoded together with the initial state and public keys and is added to the transaction via an ```condition``` in the inputs or outputs.
+
+```python
+    condition_uri_zen = zenroomscpt.condition.serialize_uri()
+    unsigned_fulfillment_dict_zen = {
+        "type": zenroomscpt.TYPE_NAME,
+        "public_key": base58.b58encode(signer.public_key).decode(),
+    }
+    output = {
+        "amount": "10",
+        "condition": {
+            "details": unsigned_fulfillment_dict_zen,
+            "uri": condition_uri_zen,
+        },
+        "public_keys": [
+            signer.public_key,
+        ],
+    }
+```
+
+The script tag can then be used to define inputs and expected outputs
+```json
+    script_ = {
+        "code": {"type": "zenroom", "raw": "test_string", "parameters": [{"obj": "1"}, {"obj": "2"}]},  # obsolete
+        "state": "dd8bbd234f9869cab4cc0b84aa660e9b5ef0664559b8375804ee8dce75b10576",
+        "input": SCRIPT_INPUT,
+        "output": ["ok"],
+        "policies": {},
+    }
+```
+
+The script tag and the script to fulfill the conditions is then added to the initial script and signed by the actor (in this case alice):
+
+```
+  signed_input = zenroomscpt.sign(script_, CONDITION_SCRIPT, alice)
+```
+
+The state of the script can then be verified by executing the initial ```FULFILL_SCRIPT```. Therefore, the output of the ```CONDITION_SCRIPT``` execution in combination with ```script_``` needs to be mapped to the input and some output needs to be removed first:
+
+```
+  input_signed = json.loads(signed_input)
+  input_signed["input"]["signature"] = input_signed["output"]["signature"]
+  del input_signed["output"]["signature"]
+  del input_signed["output"]["logs"]
+```
+This can now be verified by executing the scripts locally
+```
+  input_msg = json.dumps(input_signed)
+  zenroomscpt.validate(message=input_msg)
+```
+
+or by adding the context of the script executing to the transaction, singing it and sending it to planetmint
+
+```
+  # add the fulfillment and the signed input
+  tx["inputs"][0]["fulfillment"] = fulfillment_uri_zen
+  tx["script"] = input_signed
+  tx["id"] = None
+
+  # convert the json string
+  json_str_tx = json.dumps(tx, sort_keys=True, skipkeys=False, separators=(",", ":"))
+
+  # SHA3: hash the serialized id-less transaction to generate the id
+  shared_creation_txid = sha3_256(json_str_tx.encode()).hexdigest()
+  tx["id"] = shared_creation_txid
+  
+  # send the signed TX to planetmint
+  plntmnt = Planetmint(os.environ.get("PLANETMINT_ENDPOINT"))
+  sent_transfer_tx = plntmnt.transactions.send_commit(tx)
+```
+
+
+### Reusealbe contracts - state-ful contracts
 A contract can persist states after being created. This can be achieved by the `TRANSFER` transaction. This type of transaction enables the contract to persist data in the result-output in such a way that it can be reutilized in the next iteration/exeuction. Therewith, states can be referenced without the need to extend the framework or the integration. It's more a matter of a convention like on memory stacks. Handover-routines need to be defined to make it transparent.

--- a/13/README.md
+++ b/13/README.md
@@ -1,0 +1,61 @@
+```
+shortname: PRP-13
+name: Zenroom calling convention
+type: Draft
+status: Raw
+editor: Jürgen Eckel <juergen@riddleandcode.com>
+```
+
+## Abstract
+Planetmint integrates Zenroom smart contracts via the integration of zenroom into [cryptoconditions](https://github.com/planetmint/cryptoconditions).
+The concept of Smart Policies can be derived and integrated with zenroom and the cryptoncidtiona and the transaction schema.
+
+
+## Motivation
+Smart contract are a very powerful concept. At the same time, you need to explicitly interact with them. An explicit defintion of input an output parameteres as well as reserved keywords is needed to enable smooth intgraitons and common understanding. 
+
+## Specification
+Planetmint adapt the concept of cryptoconditions. Zenroom based execution on cryptoconditions is defined as follows:
+```
+zenSha = ZenroomSha256(script=fulfill_script, keys=zen_public_keys, data=data)
+```
+
+### Validation & Verification
+A zenroom script/contract/policy is verified via a certain input:
+```
+assert zenSha.validate(message=message)
+```
+and verifies if this input is a valid input for the above mentioned fulfill script of the ZenroomSha256 call.
+
+### Signing
+Signing of a contarct is done by calling
+```
+zenSha.sign(script_input, condition_script, alice)
+```
+This will execute the conditional script together with the private keys of alice and the script input. 
+
+Usually, the validation script can verify if the conditional script executed as requested by passing the output data (e.g. signatures) from the signing process to the validate call. 
+
+### Inputs & Outputs
+The zenroom/zencode integration of Planetmint defines the following calling input/output convention for the contracts/policies/scritps.
+
+The input messages (e.g. the script inputs) are expected to be structured as follows:
+```
+{
+    "input" : {
+
+    },
+    "output" : {
+
+    }
+    "signature": {
+
+    }
+}
+```
+The "input" contains all the data that is to be passed to the script being exectued (fulfilled, verified, ...).
+The "output" contains all the output data of the script/contract/policy execution including the exectuion logs.
+The "signature" is a special case output value. This value is automatically merged into the script input if it is passed from a message signing call into the validate method.
+
+The major tags: "input", "output", and "signature" are therefore predefined tags that must not be used otherwise.
+

--- a/README.md
+++ b/README.md
@@ -20,5 +20,6 @@ Short Name   | Title                                                         | T
 [PRP-8](8)   | Adding tradable asset attribution - attribution/material balance| Informational | Raw        | Jürgen Eckel
 [PRP-10](10)   | Stateful Smart Contracts | Draft | Raw        | Jürgen Eckel
 [PRP-11](11)   | Smart Policies | Draft | Raw        | Jürgen Eckel
+[PRP-13](13)   | Zenroom calling convention | Draft | Raw        | Jürgen Eckel
 
 


### PR DESCRIPTION
Make sure the title of this pull request has the form:

The zenroom calling convention was implicitly defined by the integration. 
Too many scenarios where possible and a well defined approach was missing structured the behavior in a clear way.

## Solution

A precise and clear way on how to call zenroom got proposed and defined in PRP 13.
This got integrated into the cryptoconditions.

## Issues Resolved
Undefined calling convention of zenroom.

## Checklist

- [X] version number increased
- [X] CHANGELOG.md updated
- [X] unit test added (adapted)
- [X] documentation updated or added